### PR TITLE
Enable NFS synced folder by default

### DIFF
--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -10,9 +10,13 @@ Vagrant.configure("2") do |config|
   # Expose the Docker port
   config.vm.network :forwarded_port, guest: 4243, host: 4243
 
+  # Enable NFS synced folder by default
+  config.vm.synced_folder ".", "/vagrant", type: "nfs"
+
   # Attach the b2d ISO so that it can boot
   config.vm.provider :virtualbox do |v|
     v.check_guest_additions = false
+    v.functional_vboxsf = false
     v.customize "pre-boot", [
       "storageattach", :id,
       "--storagectl", "IDE Controller",
@@ -27,6 +31,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :parallels do |p|
     p.check_guest_tools = false
+    p.functional_psf = false
     p.customize "pre-boot", [
       "set", :id,
       "--device-set", "cdrom0",


### PR DESCRIPTION
- Disable the default synced folder implementation
- Enable NFS synced folder by default to omit an inappropriate error message in case of no synced_folder settings in user's Vagrantfile

To tell the truth, I want to disable synced folder by default to omit any error messages.
But it will force users to add `dsabled: false` in `config.vm.synced_folder ".", "/vagrant", type: "nfs"`, if they want to enable it back in their Vagrantfile.
It's not good and not compatible with existing Vagrantfiles.

So I will pull request to fix this behavior of Vagrant.
vagrant/plugins/kernel_v2/config/vm.rb

``` ruby
      def synced_folder(hostpath, guestpath, options=nil)
        if Vagrant::Util::Platform.windows?
          # On Windows, Ruby just uses normal '/' for path seps, so
          # just replace normal Windows style seps with Unix ones.
          hostpath = hostpath.to_s.gsub("\\", "/")
        end

        options ||= {}
        options[:guestpath] = guestpath.to_s.gsub(/\/$/, '')
        options[:hostpath]  = hostpath
+       options[:disabled]  = options[:disabled] || false
        options = (@__synced_folders[options[:guestpath]] || {}).
          merge(options.dup)

        # Make sure the type is a symbol
        options[:type] = options[:type].to_sym if options[:type]

        @__synced_folders[options[:guestpath]] = options
      end
```
