### PR TITLE
Auto correct port 2375

### DIFF
--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   config.ssh.username = "docker"
 
   # Forward the Docker port
-  config.vm.network :forwarded_port, guest: 2375, host: 2375
+  config.vm.network :forwarded_port, guest: 2375, host: 2375, auto_correct: true
   # Forward the old port for a while, too
   config.vm.network :forwarded_port, guest: 2375, host: 4243, auto_correct: true
 


### PR DESCRIPTION
Despite port 2375 being registered to docker, I feel it is worth setting this port to also auto correct in the event that the user is creating more than one instance of boot2docker on their system.
