### PR TITLE
updated packer template to install packer onto /dev/sdb1

### DIFF
--- a/template.json
+++ b/template.json
@@ -3,7 +3,7 @@
         "name": "virtualbox",
         "type": "virtualbox-iso",
         "iso_url": "boot2docker.iso",
-        "iso_checksum": "92e9d0fa63463f9411a08860f7ea68e1",
+        "iso_checksum": "92e9d0fa63463f9411a08860f7ea68e1",        
         "iso_checksum_type": "md5",
         "boot_wait": "5s",
         "ssh_username": "docker",
@@ -14,6 +14,8 @@
         "disk_size": 40960,
         "hard_drive_interface": "sata",
         "vboxmanage": [
+            ["createhd", "--filename", "packer-hd", "--size", "512"],
+
             ["modifyvm", "{{.Name}}", "--memory", "512"],
             ["modifyvm", "{{.Name}}", "--nictype1", "virtio"],
             ["modifyvm", "{{.Name}}", "--nictype2", "virtio"],
@@ -22,7 +24,14 @@
             ["modifyvm", "{{.Name}}", "--nictype5", "virtio"],
             ["modifyvm", "{{.Name}}", "--nictype6", "virtio"],
             ["modifyvm", "{{.Name}}", "--nictype7", "virtio"],
-            ["modifyvm", "{{.Name}}", "--nictype8", "virtio"]
+            ["modifyvm", "{{.Name}}", "--nictype8", "virtio"],
+           
+            ["storageattach", "{{.Name}}", 
+            "--storagectl","SATA Controller", 
+            "--type","hdd",
+            "--device","0",
+            "--port","29",
+            "--medium", "packer-hd.vdi"]
         ]
     }, {
         "name": "parallels",
@@ -51,15 +60,27 @@
             "sudo mkfs.ext4 -F -L boot2docker-data /dev/sda1",
             "sudo swapon /dev/sda2",
 
+
+            "(echo n; echo p; echo 1; echo ; echo ; echo w) | sudo fdisk /dev/sdb",
+            "sudo mkfs.ext4 -F -L packer /dev/sdb1",
+
             "sudo /usr/local/etc/init.d/docker stop",
             "sudo /etc/rc.d/automount",
 
-            "mkdir -p /tmp/boot2docker"
+            "sudo mkdir -p /mnt/sdb1",
+            "sudo mount /dev/sdb1 /mnt/sdb1",
+
+            "mkdir -p /tmp/boot2docker",
+            "mkdir -p /tmp/packer"
         ]
     }, {
         "type": "file",
         "source": "files/",
         "destination": "/tmp/boot2docker"
+    },{
+        "type": "file",
+        "source": "packer/",
+        "destination": "/tmp/packer"
     }, {
         "type": "shell",
         "inline": [
@@ -73,7 +94,14 @@
 
             "sudo mkdir -p /var/lib/boot2docker/bin",
             "sudo cp /tmp/boot2docker/docker-enter /var/lib/boot2docker/bin/",
-            "sudo chmod +x /var/lib/boot2docker/bin/docker-enter"
+            "sudo chmod +x /var/lib/boot2docker/bin/docker-enter",
+
+            "echo checking directory content---------",
+            "ls -l -a /tmp/packer",
+
+            "sudo cp /tmp/packer/* /mnt/sdb1",
+            "sudo chmod +x /mnt/sdb1/*",
+            "echo -------------"
         ]
     }],
 


### PR DESCRIPTION
@YungSang 

Not sure if you care about this or not but if you are we can discuss how to merge.  

This is not a fully working patch because it doesn't include the packer binaries itself.

If you are running on OS X but want to use packer to build docker images (especially during development) you need to have a copy of packer that can run on linux.  The obvious place to put it was inside the boot2docker image so that you can `vagrant ssh -c "/mnt/sdb1/packer blah blah blah"` when you want to build images.  This avoids having two different build schemes one for dev (with `Dockerfile`) and another for deployment with packer when you want to build EC2 images, etc.

I'm pretty sure a better solution would be to have packer understand the `DOCKER_HOST` environment variable but I didn't want to take that project on.

Another small problem is that I don't know enough coreos/systemd mojo to figure out how to get the booted vagrant box to automatically mount `/dev/sdb1` onto `/mnt/sdb1` but you probably know how to do this anyway since you got the original one working correctly for `/dev/sda1`.
